### PR TITLE
fix: Add pynput as dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pynput==1.7.7
 PySide2==5.15.2.1
 pywin32==306
 PyYAML==6.0.1
-requests==2.31.0
+requests==2.32.3
 win10toast==0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ chardet==5.2.0
 pandas==1.4.2
 paramiko==3.4.0
 pygame==2.5.2
+pynput==1.7.7
 PySide2==5.15.2.1
 pywin32==306
 PyYAML==6.0.1


### PR DESCRIPTION
Per the recent changes in the code, `pynput` is now a dependency.  Running `pip install` on `requirements.txt` prior to this commit does not install `pynput` which is required in `TaskWindow.py`.

Also bumps up `requests` to 2.32.3, which fixes a security vulnerability found in the earlier version of `requests` used by this package (https://github.com/SijieZhuo/PrecisionEmailSimulator/security/dependabot/1).